### PR TITLE
fix: updated create_fllow_activity script

### DIFF
--- a/orb/kustomize/orb/overlays/common/testnet/create_follow_activity.sh
+++ b/orb/kustomize/orb/overlays/common/testnet/create_follow_activity.sh
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-echo "Adding curl"
-apk --no-cache add wget
+echo "Adding wget"
+type wget || apk --no-cache add wget
 
 rm -rf .build
 mkdir -p .build


### PR DESCRIPTION
Updated the incorrect output being printed.
Also added a trivial check if `wget` is not installed, only then proceed to install it.